### PR TITLE
fix textnode interpolation of Frags

### DIFF
--- a/src/main/scala/org/getshaka/shaka/Helpers.scala
+++ b/src/main/scala/org/getshaka/shaka/Helpers.scala
@@ -10,4 +10,4 @@ def render(frag: Frag, element: Element): Unit =
   Frag.render(frag)(using element, RootBinding())
 
 extension (f: Frag)
-  inline def render(using Element, Binding[?]): Unit = Frag.render(f)
+  def render(using Element, Binding[?]): Unit = Frag.render(f)


### PR DESCRIPTION
The `t""` interpolator is the one macro of this project, and doesn't seem to work when this method is `inline`